### PR TITLE
deterministic flag

### DIFF
--- a/just_sh/convert.py
+++ b/just_sh/convert.py
@@ -789,7 +789,9 @@ class CompilerState:
         return unique_targets
 
 
-def _compile(compiler_state: CompilerState, outfile_path: str, justfile: str, deterministic: bool) -> str:
+def _compile(
+    compiler_state: CompilerState, outfile_path: str, justfile: str, deterministic: bool
+) -> str:
     def header_comment(text: str) -> str:
         border = "#" * 89
         return f"""{border}
@@ -797,7 +799,6 @@ def _compile(compiler_state: CompilerState, outfile_path: str, justfile: str, de
 {border}"""
 
     def autogen_comment() -> str:
-
         if deterministic:
             compilation_timestamp_msg = " "
         else:
@@ -1844,13 +1845,18 @@ fi
 ########################################################################################
 
 
-def compile(justfile: str, outfile_path: str, verbose: bool, deterministic: bool) -> str:
+def compile(
+    justfile: str, outfile_path: str, verbose: bool, deterministic: bool
+) -> str:
     compiler_state = CompilerState(justfile_parse(justfile, verbose=verbose))
     return _compile(compiler_state, outfile_path, justfile, deterministic=deterministic)
 
 
 def main(
-    justfile_path: Optional[str], outfile_path: str, verbose: bool = False, deterministic: bool = False
+    justfile_path: Optional[str],
+    outfile_path: str,
+    verbose: bool = False,
+    deterministic: bool = False,
 ) -> None:
     if justfile_path is None:
         for filename in ["justfile", ".justfile", "Justfile", ".Justfile"]:
@@ -1874,10 +1880,16 @@ def main(
             justfile_data = f.read()
 
     if outfile_path == "-":
-        sys.stdout.write(compile(justfile_data, "just.sh", verbose, deterministic=deterministic))
+        sys.stdout.write(
+            compile(justfile_data, "just.sh", verbose, deterministic=deterministic)
+        )
     else:
         with open(outfile_path, "w") as f:
-            f.write(compile(justfile_data, outfile_path, verbose, deterministic=deterministic))
+            f.write(
+                compile(
+                    justfile_data, outfile_path, verbose, deterministic=deterministic
+                )
+            )
         os.chmod(outfile_path, os.stat(outfile_path).st_mode | stat.S_IEXEC)
 
 
@@ -1894,7 +1906,12 @@ def cli_entrypoint() -> None:
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose parser output"
     )
-    parser.add_argument("-d", "--deterministic", action="store_true", help="Ensure deterministic output. Strips compilation timestamp.")
+    parser.add_argument(
+        "-d",
+        "--deterministic",
+        action="store_true",
+        help="Ensure deterministic output. Strips compilation timestamp.",
+    )
     parser.add_argument("--version", action="store_true", help="Print version string")
     parsed_args = parser.parse_args()
 
@@ -1911,7 +1928,12 @@ def cli_entrypoint() -> None:
             "Call `./just.sh` instead of `just.sh` to execute the generated script."
         )
 
-    main(parsed_args.infile, parsed_args.outfile, verbose=parsed_args.verbose, deterministic=parsed_args.deterministic)
+    main(
+        parsed_args.infile,
+        parsed_args.outfile,
+        verbose=parsed_args.verbose,
+        deterministic=parsed_args.deterministic,
+    )
 
 
 if __name__ == "__main__":

--- a/just_sh/convert.py
+++ b/just_sh/convert.py
@@ -800,17 +800,17 @@ def _compile(
 
     def autogen_comment() -> str:
         if deterministic:
-            compilation_timestamp_msg = " "
+            generated_with = f"Generated with just.sh version {__version__}."
         else:
-            compilation_timestamp_msg = f""" on {
-                datetime.datetime.now().strftime('%Y-%m-%d')             
-            } """
+            generated_with = f"""Generated on {
+                datetime.datetime.now().strftime('%Y-%m-%d')
+            } with just.sh version {__version__}."""
 
         return header_comment(
             f"""
 This script was auto-generated from a Justfile by just.sh.
 
-Generated{compilation_timestamp_msg}with just.sh version {__version__}.
+{generated_with}
 https://github.com/jstrieb/just.sh
 
 Run `./{os.path.basename(outfile_path)} --dump` to recover the original Justfile.\n\n"""

--- a/just_sh/convert.py
+++ b/just_sh/convert.py
@@ -802,8 +802,8 @@ def _compile(compiler_state: CompilerState, outfile_path: str, justfile: str, de
             compilation_timestamp_msg = " "
         else:
             compilation_timestamp_msg = f""" on {
-        datetime.datetime.now().strftime('%Y-%m-%d')             
-    } """
+                datetime.datetime.now().strftime('%Y-%m-%d')             
+            } """
 
         return header_comment(
             f"""

--- a/just_sh/convert.py
+++ b/just_sh/convert.py
@@ -1874,10 +1874,10 @@ def main(
             justfile_data = f.read()
 
     if outfile_path == "-":
-        sys.stdout.write(compile(justfile_data, "just.sh", verbose))
+        sys.stdout.write(compile(justfile_data, "just.sh", verbose, deterministic=deterministic))
     else:
         with open(outfile_path, "w") as f:
-            f.write(compile(justfile_data, outfile_path, verbose))
+            f.write(compile(justfile_data, outfile_path, verbose, deterministic=deterministic))
         os.chmod(outfile_path, os.stat(outfile_path).st_mode | stat.S_IEXEC)
 
 
@@ -1911,7 +1911,7 @@ def cli_entrypoint() -> None:
             "Call `./just.sh` instead of `just.sh` to execute the generated script."
         )
 
-    main(parsed_args.infile, parsed_args.outfile, verbose=parsed_args.verbose, deterministic=parser.deterministic)
+    main(parsed_args.infile, parsed_args.outfile, verbose=parsed_args.verbose, deterministic=parsed_args.deterministic)
 
 
 if __name__ == "__main__":

--- a/test/test.py
+++ b/test/test.py
@@ -1174,6 +1174,15 @@ build:
 
     assert "Generated on" not in just_sh_content
 
+    justfile = tmpdir.join("Justfile")
+    justfile.write(justfile_content)
+    convert.main(None, "just.sh", deterministic=False)
+
+    with open("just.sh") as f:
+        just_sh_content = f.read()
+
+    assert "Generated on" in just_sh_content
+
 
 NORMALIZE_REGEXES = [
     (re.compile(rb"(\./)?just\.sh"), rb"just"),

--- a/test/test.py
+++ b/test/test.py
@@ -1173,7 +1173,7 @@ build:
         run_justfile(args + ["--deterministic"])
     parse.main("Justfile", verbose=True)
 
-    with open("just.sh", "r") as f:
+    with open("just.sh") as f:
         just_sh_content = f.read()
 
     assert "Generated on" not in just_sh_content

--- a/test/test.py
+++ b/test/test.py
@@ -1159,6 +1159,26 @@ def test_evalute_without_quoting() -> None:
     assert state.evaluate("testing", quote=False) == "testing"
 
 
+def test_deterministic(tmpdir: Any) -> None:
+    tmpdir.chdir()
+    justfile_content = """
+build:
+  echo Building…
+"""
+    justfile = tmpdir.join("Justfile")
+    justfile.write(justfile_content)
+    convert.main(None, "just.sh")
+
+    for args in FLAG_COMBOS:
+        run_justfile(args + ["--deterministic"])
+    parse.main("Justfile", verbose=True)
+
+    with open("just.sh", "r") as f:
+        just_sh_content = f.read()
+
+    assert "Generated on" not in just_sh_content
+
+
 NORMALIZE_REGEXES = [
     (re.compile(rb"(\./)?just\.sh"), rb"just"),
     (re.compile(rb"Justfile"), rb"just"),

--- a/test/test.py
+++ b/test/test.py
@@ -1167,10 +1167,7 @@ build:
 """
     justfile = tmpdir.join("Justfile")
     justfile.write(justfile_content)
-    convert.main(None, "just.sh")
-
-    run_justfile(["--deterministic"])
-    parse.main("Justfile", verbose=True)
+    convert.main(None, "just.sh", deterministic=True)
 
     with open("just.sh") as f:
         just_sh_content = f.read()

--- a/test/test.py
+++ b/test/test.py
@@ -1169,8 +1169,7 @@ build:
     justfile.write(justfile_content)
     convert.main(None, "just.sh")
 
-    for args in FLAG_COMBOS:
-        run_justfile(args + ["--deterministic"])
+    run_justfile(["--deterministic"])
     parse.main("Justfile", verbose=True)
 
     with open("just.sh") as f:


### PR DESCRIPTION
Example output:

```
#########################################################################################
#                                                                                       #
# This script was auto-generated from a Justfile by just.sh.                            #
#                                                                                       #
# Generated with just.sh version 0.0.2.                                                 #
# https://github.com/jstrieb/just.sh                                                    #
#                                                                                       #
# Run `./just.sh --dump` to recover the original Justfile.                              #
#                                                                                       #
#########################################################################################

```

I did not write a test, but am happy to if requested